### PR TITLE
use Element.prototype.matches if present

### DIFF
--- a/matches-selector.js
+++ b/matches-selector.js
@@ -12,6 +12,10 @@
   'use strict';
 
   var matchesMethod = ( function() {
+    // check for the standard method name first
+    if ( ElemProto.matches ) {
+      return 'matches';
+    }
     // check un-prefixed
     if ( ElemProto.matchesSelector ) {
       return 'matchesSelector';


### PR DESCRIPTION
The matchesSelector method dropped the "Selector" part on its way to the [DOM Living Standard](https://dom.spec.whatwg.org/#dom-element-matches).

Some [browsers](http://caniuse.com/#feat=matchesselector) already implement the .matches method.