### PR TITLE
Fixes DOM issues when running tests in mocha

### DIFF
--- a/matches-selector.js
+++ b/matches-selector.js
@@ -25,7 +25,7 @@
   'use strict';
 
   var matchesMethod = ( function() {
-    var ElemProto = Element.prototype;
+    var ElemProto = window.Element.prototype;
     // check for the standard method name first
     if ( ElemProto.matches ) {
       return 'matches';


### PR DESCRIPTION
In one of my projects, I'm attempting to add Masonry. 
However, with our current test suite, Mocha complains about `Element` being undefined in `matches-selector`.  This is small change fixes our issue, and don't break the current `matches-selector` tests.

Any thoughts?